### PR TITLE
Asynchronous WebUI Settings

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -305,7 +305,9 @@ rTorrentStub.prototype.setuisettings = function()
 rTorrentStub.prototype.getuisettings = function()
 {
 	this.mountPoint = theURLs.GetSettingsURL;
-	this.dataType = "json";
+	this.dataType = "text";
+	this.contentType = "text/plain";
+	this.method = 'GET';
 }
 
 rTorrentStub.prototype.getplugins = function()

--- a/js/webui.js
+++ b/js/webui.js
@@ -311,6 +311,7 @@ var theWebUI =
 
 	getPlugins: function()
 	{
+		this.requestWithoutTimeout("?action=getuisettings", [this.receiveJsonFilePath, this], true);
 		this.requestWithoutTimeout("?action=getplugins", [this.getUISettings, this]);
 	},
 
@@ -328,21 +329,25 @@ var theWebUI =
 		correctContent();
 		this.updateServerTime();
 		window.setInterval( this.updateServerTime, 1000 );
-		this.requestWithoutTimeout("?action=getuisettings", [this.initFinish, this]);
+		this.initFinish();
+	},
+	
+	receiveJsonFilePath: function(path)
+	{
+		$.getJSON(path, this.addSettings.bind(this));
 	},
 
-	initFinish: function(data)
+	initFinish: function()
 	{
-		this.config(data);
-	        this.catchErrors(true);
+		this.config();
+		this.catchErrors(true);
 		this.assignEvents();
 		this.resize();
 		this.update();		
 	},
 
-	config: function(data)
+	config: function()
 	{
-		this.addSettings(data);
 		$.each(this.tables, function(ndx,table)
 		{
 		        var width = theWebUI.settings["webui."+ndx+".colwidth"];
@@ -774,7 +779,7 @@ var theWebUI =
 		else
 		{
 			if(this.systemInfo.rTorrent.started)
-		   		this.request("?action=getsettings", [this.addAndShowSettings, this], true);
+				this.request("?action=getsettings", [this.addAndShowSettings, this], true);
 			else
 				this.addAndShowSettings();
 		}

--- a/php/getsettings.php
+++ b/php/getsettings.php
@@ -2,19 +2,6 @@
 
 require_once( 'util.php' );
 
-$s = '{}';
-$fname = getSettingsPath()."/uisettings.json";
-$fo = @fopen($fname, 'r');
-if($fo!==false)
-{
-	if(flock($fo, LOCK_SH))
-	{
-		$s = @file_get_contents($fname);
-		if($s==false)
-			$s = '{}';
-		flock($fo, LOCK_UN); 
-	}
-	fclose($fo); 
-}
-
-cachedEcho($s,"application/json",true);
+$fname = getWebUIJsonFile()."/uisettings.json";
+@chmod($fname, 0777);
+cachedEcho($fname, "text/plain", true);

--- a/php/util.php
+++ b/php/util.php
@@ -393,6 +393,32 @@ function getUploadsPath( $user = null )
 	return( getProfilePath($user).'/torrents' );
 }
 
+function getWebUIJsonFile()
+{
+	global $profilePath;
+	$ret.= isset($profilePath) ? $profilePath : '../share';
+	$ret = str_replace('..', '', $ret);
+	
+	if(is_null($user))
+		$user = getUser();
+
+	if($user!='')
+	{
+		$ret.=('/users/'.$user);
+		if(!is_dir($ret))
+			makeDirectory( array($ret,$ret.'/settings',$ret.'/torrents',$ret.'/tmp') );
+	}
+	
+	// Get the path of the ruTorrent folder
+	$ruTorrent = dirname(dirname( __FILE__ ));
+	
+	// Append the path to the full settings url
+	$ret = $ruTorrent.$ret.'/settings';	
+	
+	// Remove the parent directories, so the file path becomes relative
+	return str_replace(dirName($ruTorrent), '', $ret);
+}
+
 function getUniqueFilename($fname)
 {
 	while(file_exists($fname))


### PR DESCRIPTION
This pull request moves loading the JSON file for WebUI settings from PHP to Javascript. This allows dispatching of an alternate thread to perform this task, so we don't have to wait for the plugins to finish loading. This task can be done asynchronously without any negative impacts. All we need to do is request the file location from PHP. The settings being loaded here are just basic UI settings, which can be updated on the web server at any time. They have absolutely no dependencies.

Performance wise, this reduces loading times by approximately 300ms on average. In extremely bad cases, it may take seconds off the loading time. It also reduces web server load because we're not streaming the file contents anymore to send them. JQuery simply downloads the file to the local computer then creates a JSON object out of it. The file is only 3.2kb, so it's done very quick.