### PR TITLE
Improve file path lookups

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -22,9 +22,21 @@
 	// for php
 	@define('PHP_USE_GZIP', false, false);
 	@define('PHP_GZIP_LEVEL', 2, true);
+	
 
-	$schedule_rand = 10;			// rand for schedulers start, +0..X seconds
-
+class RTorrentConfig
+{	
+	public $schedule_rand = 10;	// rand for schedulers start, +0..X seconds
+	
+	public $pathToExternals = array(
+		"php" 	=> '',			// Something like /usr/bin/php. If empty, will be found in PATH.
+		"curl"	=> '',			// Something like /usr/bin/curl. If empty, will be found in PATH.
+		"gzip"	=> '',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
+		"id"	=> '',			// Something like /usr/bin/id. If empty, will be found in PATH.
+		"stat"	=> '',			// Something like /usr/bin/stat. If empty, will be found in PATH.
+	);	
+}
+	
 	$do_diagnostic = true;
 	$log_file = '/tmp/errors.log';		// path to log file (comment or leave blank to disable logging)
 
@@ -45,14 +57,6 @@
 	// $scgi_host = "unix:///tmp/rpc.socket";
 
 	$XMLRPCMountPoint = "/RPC2";		// DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
-
-	$pathToExternals = array(
-		"php" 	=> '',			// Something like /usr/bin/php. If empty, will be found in PATH.
-		"curl"	=> '',			// Something like /usr/bin/curl. If empty, will be found in PATH.
-		"gzip"	=> '',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
-		"id"	=> '',			// Something like /usr/bin/id. If empty, will be found in PATH.
-		"stat"	=> '',			// Something like /usr/bin/stat. If empty, will be found in PATH.
-	);
 
 	$localhosts = array( 			// list of local interfaces
 		"127.0.0.1",

--- a/php/ExternalPath.php
+++ b/php/ExternalPath.php
@@ -1,0 +1,111 @@
+<?php
+
+require_once( dirname(__FILE__)."/../conf/config.php");
+require_once( "cache.php" );
+
+class ExternalPath extends RTorrentConfig {
+	
+	public $hash = "ExternalPath.dat";
+	
+	public static function load()
+	{
+		$cache = new rCache();
+		$external = new ExternalPath();
+		if(!$cache->get($external))
+		{
+			$external->updateExternalPaths();
+			$cache->set($external);			
+		}			
+		return($external);
+	}
+	
+	public function store()
+	{
+		$cache = new rCache();
+		return $cache->set($this);	
+	}
+	
+	private function updateExternalPaths()
+	{
+		foreach ($this->pathToExternals as $key => $value)
+		{
+			if (!$this->isExternalPathSet($key))
+			{
+				$this->pathToExternals[$key] = $this->findExternalPath($key);
+			}
+		}
+	}
+
+	// Returns if the external path to the program is set
+	public function isExternalPathSet($exe)
+	{
+		return(isset($this->pathToExternals[$exe]) && !empty($this->pathToExternals[$exe]));
+	}
+	
+	// Returns the external path to the program. 
+	public function getExternalPath($exe)
+	{
+		return($this->pathToExternals[$exe]);
+	}
+	
+	// Returns external path to the program if set. If not set, returns name of program
+	public function getExternalPathEx($exe)
+	{
+		return($this->isExternalPathSet($exe) ? $this->pathToExternals[$exe] : $exe);
+	}
+	
+	// Wrapper which returns etheir the path to php or the word php
+	public function getPHP()
+	{
+		return($this->getExternalPathEx("php"));
+	}
+	
+	// Long way of fetching an external path. Useful for internal lookups
+	public function findExternalPath( $exe )
+	{
+		$result = $this->performPathLookup($exe);
+		return $result === false ? '' : $result;
+	}
+	
+	// Long way of fetching an external path. Useful for resolving errors
+	public function fetchExternalPath($exe)
+	{
+		// If path is already in array, just return it
+		if ($this->isExternalPathSet($exe))
+			return $this->getExternalPath($exe);
+		
+		return $this->performPathLookup($exe);
+	}
+	
+	private function performPathLookup($exe)
+	{
+		// Try the 'which' shell command first. Check for a valid output
+		// The 'PATH' environment method may not work properly
+		// The 'which' command also has performance advantages
+		$cmd = shell_exec('which '.$exe);
+		if (isset($cmd) && !empty($cmd))
+		{
+			// Trim string, update array, update cache, return value
+			$loc = trim($cmd);
+			$this->pathToExternals[$exe] = $loc;
+			$this->store();
+			return $loc;			
+		}
+		
+		// Otherwise look through all the environment paths
+		$path = explode(":", getenv('PATH'));
+		foreach($path as $tryThis)
+		{
+			// Check if the file is found in the folder
+			$fname = $tryThis . '/' . $exe;
+			if(is_executable($fname))
+			{
+				// Update array, update cache, return value
+				$this->pathToExternals[$exe] = $fname;
+				$this->store();
+				return($fname);
+			}
+		}
+		return false; 		
+	}
+}

--- a/php/RemoteRequests.php
+++ b/php/RemoteRequests.php
@@ -1,0 +1,50 @@
+<?php
+require_once( "util.php" );
+require_once( "xmlrpc.php" );
+
+class RemoteRequests {	
+
+	private $remoteRequests = array();	
+	private $external = null;
+	
+	public function __construct(ExternalPath $path)
+	{
+		$this->external = $path;
+	}
+	
+	public function findRemoteEXE( $exe, $err)
+	{
+		if(!array_key_exists($exe,$this->remoteRequests))
+		{
+			$path=realpath(dirname('.'));
+			$st = getSettingsPath().'/'.rand();
+			$cmd = array( "sh", addslash($path)."test.sh", $exe, $st );
+			
+			if($this->external->isExternalPathSet($exe))
+				$cmd[] = $this->external->getExternalPath($exe);
+			
+			$req = new rXMLRPCRequest(new rXMLRPCCommand("execute", $cmd));
+			$req->run();
+			$this->remoteRequests[$exe] = array( "path"=>$st, "err"=>array() );
+		}
+		$this->remoteRequests[$exe]["err"][] = $err;
+	}
+
+	public function getJResultErrorString()
+	{
+		$ret = "";
+		foreach($this->remoteRequests as $exe=>$info)
+		{
+			$file = $info["path"].$exe.".found";
+			if(!is_file($file))
+			{
+				foreach($info["err"] as $err)
+					$ret.=$err;
+			}
+			else
+				@unlink($file);
+		}			
+		
+		return($ret);
+	}
+}

--- a/php/Snoopy.class.inc
+++ b/php/Snoopy.class.inc
@@ -92,6 +92,12 @@ class Snoopy
 
 	var $_isproxy		=	false;			// set if using a proxy server
 	var $_fp_timeout	=	30;			// timeout for socket connection
+	
+	/**** Path Varriables ***/
+	
+	var $_externalPath  = null;			// ExternalPath class for finding programs
+	var $_gzipPath 		= "";			// Path to gzip program
+	var $_curlPath		= "";			// Path to curl program
 
 	public function __construct()
 	{
@@ -113,6 +119,10 @@ class Snoopy
 		$this->use_gzip = @constant('HTTP_USE_GZIP');
 		if(isset($httpIP))
 			$this->IP = $httpIP;
+		
+		$this->_externalPath = ExternalPath::load();
+		$this->_gzipPath = $this->_externalPath->getExternalPathEx('gzip');
+		$this->_curlPath = $this->_externalPath->getExternalPathEx('curl');
 	}
 
 	static public function linkencode($p_url)
@@ -456,7 +466,7 @@ class Snoopy
 			{
 				$randName = getTempFilename('answer');
 				file_put_contents($randName.".gz",$results);
-				exec(escapeshellarg(getExternal('gzip'))." -d ".$randName.".gz",$results,$return);
+				exec(escapeshellarg($this->_gzipPath)." -d ".$randName.".gz",$results,$return);
 				if(is_file($randName))
 				{
 					$results = file_get_contents($randName);
@@ -536,7 +546,7 @@ class Snoopy
 		
 		# accept self-signed certs
 		$cmdline_params .= " -k -s "; 
-		exec(escapeshellarg(getExternal('curl'))." -g -D ".escapeshellarg($headerfile)." -o ".escapeshellarg($contfile)." ".$cmdline_params." ".escapeshellarg($url),$results,$return);
+		exec(escapeshellarg($this->_curlPath)." -g -D ".escapeshellarg($headerfile)." -o ".escapeshellarg($contfile)." ".$cmdline_params." ".escapeshellarg($url),$results,$return);
 		$this->_redirectaddr = false;
 		$this->headers = array();
 		$this->status = $return;
@@ -597,7 +607,7 @@ class Snoopy
 				{
 					$randName = getTempFilename('answer');
 					file_put_contents($randName.".gz",$results);
-					exec(escapeshellarg(getExternal('gzip'))." -d ".$randName.".gz",$results,$return);
+					exec(escapeshellarg($this->_gzipPath)." -d ".$randName.".gz",$results,$return);
 					if(is_file($randName))
 					{
 						$results = file_get_contents($randName);

--- a/php/lfs.php
+++ b/php/lfs.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once( 'ExternalPath.php' );
+
 class LFS
 {
 	static public function test($fname,$flag)
@@ -12,7 +14,8 @@ class LFS
 	static protected function statPrim($fname)
 	{
 		$out = array();
-		$st = explode(':',@exec( getExternal('stat').' -Lc%d:%i:%f:%h:%u:%g:%s:%X:%Y:%Z:%B:%b '.escapeshellarg( $fname ), $out, $ret ));
+		$stat = ExternalPath::load()->getExternalPathEx('stat');
+		$st = explode(':',@exec( $stat.' -Lc%d:%i:%f:%h:%u:%g:%s:%X:%Y:%Z:%B:%b '.escapeshellarg( $fname ), $out, $ret ));
 		return(($ret == 0) ? array( 
 		        "dev"	=>	intval($st[0]),
 			"ino"	=>	intval($st[1]),

--- a/php/settings.php
+++ b/php/settings.php
@@ -2,8 +2,9 @@
 
 require_once( 'xmlrpc.php' );
 require_once( 'cache.php');
+require_once( 'ExternalPath.php' );
 
-class rTorrentSettings
+class rTorrentSettings extends RTorrentConfig
 {
 	public $hash = "rtorrent.dat";
 	public $linkExist = false;
@@ -285,7 +286,7 @@ class rTorrentSettings
 							if($this->started===false)
 								$this->started = 0;
 						}
-						$id = getExternal('id');
+						$id = ExternalPath::load()->getExternalPathEx('id');
 						$req = new rXMLRPCRequest(
         						new rXMLRPCCommand("execute_capture",array("sh","-c",$id." -u ; ".$id." -G ; echo ~ ")));
 						if($req->run() && !$req->fault && (($line=explode("\n",$req->val[0]))!==false) && (count($line)>2))
@@ -352,21 +353,19 @@ class rTorrentSettings
 	}
 	public function getAbsScheduleCommand($name,$interval,$cmd)	// $interval in seconds
 	{
-		global $schedule_rand;
-		if(!isset($schedule_rand))
-			$schedule_rand = 10;
-		$startAt = $interval+rand(0,$schedule_rand);
+		if(!isset($this->schedule_rand))
+			$this->schedule_rand = 10;
+		$startAt = $interval+rand(0,$this->schedule_rand);
 		return( new rXMLRPCCommand("schedule", array( $name.getUser(), $startAt."", $interval."", $cmd )) );
 	}
 	public function getScheduleCommand($name,$interval,$cmd,&$startAt = null)	// $interval in minutes
 	{
-		global $schedule_rand;
-		if(!isset($schedule_rand))
-			$schedule_rand = 10;
+		if(!isset($this->schedule_rand))
+			$this->schedule_rand = 10;
 		$tm = getdate();
 		$startAt = mktime($tm["hours"],
 			((integer)($tm["minutes"]/$interval))*$interval+$interval,
-			0,$tm["mon"],$tm["mday"],$tm["year"])-$tm[0]+rand(0,$schedule_rand);
+			0,$tm["mon"],$tm["mday"],$tm["year"])-$tm[0]+rand(0,$this->schedule_rand);
 		if($startAt<0)
 			$startAt = 0;
 		$interval = $interval*60;

--- a/php/util.php
+++ b/php/util.php
@@ -1,4 +1,5 @@
 <?php
+require_once( 'ExternalPath.php' );
 
 function stripSlashesFromArray(&$arr)
 {
@@ -438,32 +439,6 @@ function getTempFilename($purpose = '', $extension = null)
 	return($fname);
 }
 
-function getExternal($exe)
-{
-	global $pathToExternals;
-	return( (isset($pathToExternals[$exe]) && !empty($pathToExternals[$exe])) ? $pathToExternals[$exe] : $exe );
-}
-
-function getPHP()
-{
-	return( getExternal("php") );
-}
-
-function findEXE( $exe )
-{
-	global $pathToExternals;
-	if(isset($pathToExternals[$exe]) && !empty($pathToExternals[$exe]))
-		return(is_executable($pathToExternals[$exe]) ? $pathToExternals[$exe] : false);
-	$path = explode(":", getenv('PATH'));
-	foreach($path as $tryThis)
-	{
-		$fname = $tryThis . '/' . $exe;
-		if(is_executable($fname))
-			return($fname);
-	}
-	return(false);
-}
-
 function cachedEcho( $content, $type = null, $cacheable = false, $exit = true )
 {
 	header("X-Server-Timestamp: ".time());
@@ -495,7 +470,7 @@ function cachedEcho( $content, $type = null, $cacheable = false, $exit = true )
 		        	$encoding = 'gzip'; 
 			if($encoding && ($len>=2048))
 			{
-				$gzip = getExternal('gzip');
+				$gzip = ExternalPath::load()->getExternalPathEx('gzip');
 				header('Content-Encoding: '.$encoding); 
 				$randName = getTempFilename('answer');
 				file_put_contents($randName,$content);

--- a/plugins/_cloudflare/cloudflare.php
+++ b/plugins/_cloudflare/cloudflare.php
@@ -6,6 +6,7 @@ class rCloudflare
 {
 	protected $client = null;
 	protected $url = null;
+	protected $path = ExternalPath:load();
 
 	public function __construct( $client, $url )
 	{
@@ -23,10 +24,15 @@ class rCloudflare
 //			(stripos( $this->client->results, "jschl_answer" ) !== false) 
 			);
 	}
+	
+	private function escapeshellarg_python()
+	{
+		return escapeshellarg($path->getExternalPathEx('python'));		
+	}
 
 	public static function is_module_present()
 	{
-		exec( escapeshellarg(getExternal('python'))." -c \"import cloudscraper\" > /dev/null 2>&1", $output, $error_code);
+		exec( escapeshellarg_python()." -c \"import cloudscraper\" > /dev/null 2>&1", $output, $error_code);
 		return($error_code === 0);
 	}
 
@@ -52,7 +58,7 @@ class rCloudflare
 			{
 				$recaptcha = ",recaptcha={\"provider\": \"$cloudscraper_recaptcha[provider]\",\"api_key\": \"$cloudscraper_recaptcha[api_key]\",\"username\": \"$cloudscraper_recaptcha[username]\",\"password\": \"$cloudscraper_recaptcha[password]\"},delay=15";
 			}
-			$code = escapeshellarg(getExternal('python'))." -c ".
+			$code = escapeshellarg_python()." -c ".
 				escapeshellarg("import cloudscraper\nimport json\ntokens, user_agent = cloudscraper.get_tokens({$url}{$proxies}{$recaptcha})\nprint(json.dumps([tokens,user_agent]))");
 			$data = `{$code}`;
 			if($data &&

--- a/plugins/_task/task.php
+++ b/plugins/_task/task.php
@@ -1,5 +1,6 @@
 <?php
 require_once( dirname(__FILE__)."/../../php/xmlrpc.php" );
+require_once( dirname(__FILE__)."/../../php/ExternalPath.php" );
 
 class rTask
 {
@@ -92,7 +93,8 @@ class rTask
 					}
 				}
 				fputs($sh,'echo $last > "${dir}"/status'."\n");
-				fputs($sh,getPHP().' '.escapeshellarg(dirname(__FILE__).'/notify.php').' '.
+				$php = ExternalPath::load()->getPHP();
+				fputs($sh,$php.' '.escapeshellarg(dirname(__FILE__).'/notify.php').' '.
 					'$last "${dir}" '.
 					escapeshellarg(getUser()).' '.
 					'> /dev/null 2>> /dev/null &'."\n");
@@ -298,7 +300,9 @@ class rTask
 				if(is_null($flags))
 					$flags = intval(file_get_contents($dir.'/flags'));
 				$pid = trim(file_get_contents($dir.'/pid'));
-				self::run("kill -9 `".getExternal("pgrep")." -P ".$pid."` ; kill -9 ".$pid, ($flags & self::FLG_RUN_AS_WEB) | self::FLG_WAIT | self::FLG_RUN_AS_CMD );
+				
+				$pgrep = ExternalPath::load()->getExternalPathEx("pgrep");
+				self::run("kill -9 `".$pgrep." -P ".$pid."` ; kill -9 ".$pid, ($flags & self::FLG_RUN_AS_WEB) | self::FLG_WAIT | self::FLG_RUN_AS_CMD );
 				self::notify($dir,"TaskKill");
 			}
 			self::clean($dir);

--- a/plugins/autotools/autotools.php
+++ b/plugins/autotools/autotools.php
@@ -144,6 +144,7 @@ class rAutoTools
 	{
 		global $autowatch_interval;
 		$theSettings = rTorrentSettings::get();
+		$php = ExternalPath::load()->getPHP();
 		$req = new rXMLRPCRequest( 
 // old version fix
 			$theSettings->getOnInsertCommand(array('autolabel'.getUser(), getCmd('cat=')))
@@ -153,7 +154,7 @@ class rAutoTools
 		if($this->enable_label)
 			$cmd = 	$theSettings->getOnInsertCommand(array('_autolabel'.getUser(), 
 				getCmd('branch').'=$'.getCmd('not').'=$'.getCmd("d.get_custom1").'=,"'.
-				getCmd('execute').'={'.getPHP().','.$pathToAutoTools.'/label.php,$'.getCmd("d.get_hash").'=,'.getUser().'}"'));
+				getCmd('execute').'={'.$php.','.$pathToAutoTools.'/label.php,$'.getCmd("d.get_hash").'=,'.getUser().'}"'));
 		else
 			$cmd = 	$theSettings->getOnInsertCommand(array('_autolabel'.getUser(), getCmd('cat=')));
 		$req->addCommand($cmd);
@@ -163,7 +164,7 @@ class rAutoTools
 			{
 				$cmd = 	$theSettings->getOnFinishedCommand(array('automove'.getUser(), 
 						getCmd('d.set_custom').'=x-dest,"$'.getCmd('execute_capture').
-						'={'.getPHP().','.$pathToAutoTools.'/move.php,$'.getCmd('d.get_hash').'=,$'.getCmd('d.get_base_path').'=,$'.
+						'={'.$php.','.$pathToAutoTools.'/move.php,$'.getCmd('d.get_hash').'=,$'.getCmd('d.get_base_path').'=,$'.
 						getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').'=,$'.getCmd('d.get_custom1').'=,$'.getCmd('d.get_name').'=,'.getUser().'}" ; '.
 						getCmd('branch').'=$'.getCmd('not').'=$'.getCmd('d.get_custom').'=x-dest,,'.getCmd('d.set_directory_base').'=$'.getCmd('d.get_custom').'=x-dest'
 					));
@@ -174,9 +175,9 @@ class rAutoTools
 				{
 					$cmd = 	$theSettings->getOnFinishedCommand(array('automove'.getUser(), 
 							getCmd('d.set_directory_base').'="$'.getCmd('execute_capture').
-							'={'.getPHP().','.$pathToAutoTools.'/check.php,$'.getCmd('d.get_base_path').'=,$'.
+							'={'.$php.','.$pathToAutoTools.'/check.php,$'.getCmd('d.get_base_path').'=,$'.
 							getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').'=,$'.getCmd('d.get_custom1').'=,$'.getCmd('d.get_name').'=,'.getUser().'}" ; '.
-							getCmd('execute').'={'.getPHP().','.$pathToAutoTools.'/move.php,$'.getCmd('d.get_hash').'=,$'.getCmd('d.get_base_path').'=,$'.
+							getCmd('execute').'={'.$php.','.$pathToAutoTools.'/move.php,$'.getCmd('d.get_hash').'=,$'.getCmd('d.get_base_path').'=,$'.
 							getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').'=,$'.getCmd('d.get_custom1').'=,$'.getCmd('d.get_name').'=,'.getUser().'}'
 						));
 				}
@@ -184,7 +185,7 @@ class rAutoTools
 				{
 					$cmd = 	$theSettings->getOnFinishedCommand(array('automove'.getUser(),
 							getCmd('d.set_custom').'=x-dest,"$'.getCmd('execute_capture'). 
-							'={'.getPHP().','.$pathToAutoTools.'/move.php,$'.getCmd('d.get_hash').'=,$'.getCmd('d.get_base_path').'=,$'.
+							'={'.$php.','.$pathToAutoTools.'/move.php,$'.getCmd('d.get_hash').'=,$'.getCmd('d.get_base_path').'=,$'.
 							getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').'=,$'.getCmd('d.get_custom1').'=,$'.getCmd('d.get_name').'=,'.getUser().'}"'
 						));
 				}
@@ -195,7 +196,7 @@ class rAutoTools
 		$req->addCommand($cmd);
 		if($this->enable_watch && (trim($this->path_to_watch)!='')) 
 			$cmd = 	$theSettings->getAbsScheduleCommand('autowatch',$autowatch_interval,
-				getCmd('execute').'={sh,-c,'.escapeshellarg(getPHP()).' '.escapeshellarg($pathToAutoTools.'/watch.php').' '.escapeshellarg(getUser()).' &}' );
+				getCmd('execute').'={sh,-c,'.escapeshellarg($php).' '.escapeshellarg($pathToAutoTools.'/watch.php').' '.escapeshellarg(getUser()).' &}' );
 		else
 			$cmd = $theSettings->getRemoveScheduleCommand('autowatch');
 		$req->addCommand($cmd);

--- a/plugins/autotools/label.php
+++ b/plugins/autotools/label.php
@@ -12,13 +12,15 @@ if( count( $argv ) > 1 )
 
 require_once( "./util_rt.php" );
 require_once( "./autotools.php" );
+require_once( dirname(__FILE__).'/../../php/ExternalPath.php');
 eval( getPluginConf( 'autotools' ) );
 
 // If we are not in background, run this script in background
 array_shift( $argv );
 if( !rtIsDaemon( $argv ) )
 {
-	rtDaemon( getPHP(), basename( __FILE__ ), $argv );
+	$php = ExternalPath::load()->getPHP();
+	rtDaemon( $php, basename( __FILE__ ), $argv );
 	// script was exited at the line above
 }
 

--- a/plugins/create/action.php
+++ b/plugins/create/action.php
@@ -170,10 +170,10 @@ if(isset($_REQUEST['cmd']))
 						'hybrid'=>$_REQUEST['hybrid']
 					) );
 					$commands = array();
-
+					$php = ExternalPath::load()->getPHP();
 					$commands[] = escapeshellarg($rootPath.'/plugins/create/'.$useExternal.'.sh')." ".
 					$task->id." ".
-					escapeshellarg(getPHP())." ".
+					escapeshellarg($php)." ".
 					escapeshellarg($pathToCreatetorrent)." ".
 					escapeshellarg($path_edit)." ".
 					$piece_size." ".

--- a/plugins/datadir/action.php
+++ b/plugins/datadir/action.php
@@ -74,7 +74,7 @@ if( isset( $HTTP_RAW_POST_DATA ) )
 	if( $hash && strlen( $datadir ) > 0 )
 	{
 		$script_dir = rtAddTailSlash( dirname( __FILE__ ) );
-		$php = getPHP();
+		$php = ExternalPath::load()->getPHP();
 		Debug( "script dir  : ".$script_dir );
 		Debug( "path to php : ".$php );
 		Debug( "hash        : ".$hash );

--- a/plugins/erasedata/init.php
+++ b/plugins/erasedata/init.php
@@ -21,7 +21,7 @@ $req = new rXMLRPCRequest( array(
 				getCmd('d.is_multi_file').'=,$'.
 				getCmd('d.get_custom5').'=}"')),
 	$theSettings->getAbsScheduleCommand("erasedata",$garbageCheckInterval,
-		getCmd('execute').'={sh,-c,'.escapeshellarg(getPHP()).' '.escapeshellarg($thisDir.'/update.php').' '.escapeshellarg(getUser()).' &}' )
+		getCmd('execute').'={sh,-c,'.escapeshellarg($ep->getPHP()).' '.escapeshellarg($thisDir.'/update.php').' '.escapeshellarg(getUser()).' &}' )
 	) );
 if($req->success())
 {

--- a/plugins/extratio/rules.php
+++ b/plugins/extratio/rules.php
@@ -241,6 +241,7 @@ class rRatioRulesList
 		global $rootPath;
 	        $throttleRulesExist = false;
 	        $ratioRulesExist = false;
+		$php = ExternalPath::load()->getPHP();
 		foreach( $this->lst as $item )
 		{
 			if($item->ratio!='')
@@ -256,7 +257,7 @@ class rRatioRulesList
 				$insCmd .= (getCmd('d.views.has=').'rat_'.$i.',,');
 			$ratCmd = 
                                 getCmd('d.set_custom').'=x-extratio1,"$'.getCmd('execute_capture').
-                                '={'.getPHP().','.$rootPath.'/plugins/extratio/update.php,\"$'.getCmd('t.multicall').'=$'.getCmd('d.get_hash').'=,'.getCmd('t.get_url').'=,'.getCmd('cat').'=#\",$'.getCmd('d.get_custom1').'=,ratio,'.getUser().'}" ; '.
+                                '={'.$php.','.$rootPath.'/plugins/extratio/update.php,\"$'.getCmd('t.multicall').'=$'.getCmd('d.get_hash').'=,'.getCmd('t.get_url').'=,'.getCmd('cat').'=#\",$'.getCmd('d.get_custom1').'=,ratio,'.getUser().'}" ; '.
                                 getCmd('branch').'=$'.getCmd('not').'=$'.getCmd('d.get_custom').'=x-extratio1,,'.$insCmd.
                                 getCmd('view.set_visible').'=$'.getCmd('d.get_custom').'=x-extratio1';
 		}
@@ -265,7 +266,7 @@ class rRatioRulesList
 		if($throttleRulesExist)
 			$thrCmd = 
                                 getCmd('d.set_custom').'=x-extratio2,"$'.getCmd('execute_capture').
-                                '={'.getPHP().','.$rootPath.'/plugins/extratio/update.php,\"$'.getCmd('t.multicall').'=$'.getCmd('d.get_hash').'=,'.getCmd('t.get_url').'=,'.getCmd('cat').'=#\",$'.getCmd('d.get_custom1').'=,channel,'.getUser().'}" ; '.
+                                '={'.$php.','.$rootPath.'/plugins/extratio/update.php,\"$'.getCmd('t.multicall').'=$'.getCmd('d.get_hash').'=,'.getCmd('t.get_url').'=,'.getCmd('cat').'=#\",$'.getCmd('d.get_custom1').'=,channel,'.getUser().'}" ; '.
                                 getCmd('branch').'=$'.getCmd('not').'=$'.getCmd('d.get_custom').'=x-extratio2,,'.
                                 getCmd('d.set_throttle_name').'=$'.getCmd('d.get_custom').'=x-extratio2';
 		else

--- a/plugins/history/history.php
+++ b/plugins/history/history.php
@@ -130,9 +130,10 @@ class rHistory
 	public function setHandlers()
 	{
 		global $rootPath;
+		$php = ExternalPath::load()->getPHP();
 		if($this->log["addition"] || ($this->log["pushbullet_enabled"] && $this->log["pushbullet_addition"]))
 		{
-			$addCmd = getCmd('execute.nothrow.bg').'={'.getPHP().','.$rootPath.'/plugins/history/update.php'.',1,$'.
+			$addCmd = getCmd('execute.nothrow.bg').'={'.$php.','.$rootPath.'/plugins/history/update.php'.',1,$'.
 				getCmd('d.get_name').'=,$'.getCmd('d.get_size_bytes').'=,$'.getCmd('d.get_bytes_done').'=,$'.
 				getCmd('d.get_up_total').'=,$'.getCmd('d.get_ratio').'=,$'.getCmd('d.get_creation_date').'=,$'.
 				getCmd('d.get_custom').'=addtime,$'.getCmd('d.get_custom').'=seedingtime'.
@@ -143,7 +144,7 @@ class rHistory
 		else
 			$addCmd = getCmd('cat=');
 		if($this->log["finish"] || ($this->log["pushbullet_enabled"] && $this->log["pushbullet_finish"]))
-			$finCmd = getCmd('execute.nothrow.bg').'={'.getPHP().','.$rootPath.'/plugins/history/update.php'.',2,$'.
+			$finCmd = getCmd('execute.nothrow.bg').'={'.$php.','.$rootPath.'/plugins/history/update.php'.',2,$'.
 				getCmd('d.get_name').'=,$'.getCmd('d.get_size_bytes').'=,$'.getCmd('d.get_bytes_done').'=,$'.
 				getCmd('d.get_up_total').'=,$'.getCmd('d.get_ratio').'=,$'.getCmd('d.get_creation_date').'=,$'.
 				getCmd('d.get_custom').'=addtime,$'.getCmd('d.get_custom').'=seedingtime'.
@@ -153,7 +154,7 @@ class rHistory
 		else
 			$finCmd = getCmd('cat=');
 		if($this->log["deletion"] || ($this->log["pushbullet_enabled"] && $this->log["pushbullet_deletion"]))
-			$delCmd = getCmd('execute.nothrow.bg').'={'.getPHP().','.$rootPath.'/plugins/history/update.php'.',3,$'.
+			$delCmd = getCmd('execute.nothrow.bg').'={'.$php.','.$rootPath.'/plugins/history/update.php'.',3,$'.
 				getCmd('d.get_name').'=,$'.getCmd('d.get_size_bytes').'=,$'.getCmd('d.get_bytes_done').'=,$'.
 				getCmd('d.get_up_total').'=,$'.getCmd('d.get_ratio').'=,$'.getCmd('d.get_creation_date').'=,$'.
 				getCmd('d.get_custom').'=addtime,$'.getCmd('d.get_custom').'=seedingtime'.

--- a/plugins/loginmgr/accounts.php
+++ b/plugins/loginmgr/accounts.php
@@ -261,9 +261,10 @@ class accountManager
 	{
 		if(rTorrentSettings::get()->linkExist)
 		{
+			$php = ExternalPath::load()->getPHP();
 			$req =  new rXMLRPCRequest( $this->hasAuto() ?
 				rTorrentSettings::get()->getAbsScheduleCommand("loginmgr",86400,
-					getCmd('execute').'={sh,-c,'.escapeshellarg(getPHP()).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(getUser()).' & exit 0}' ) :
+					getCmd('execute').'={sh,-c,'.escapeshellarg($php).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(getUser()).' & exit 0}' ) :
 				rTorrentSettings::get()->getRemoveScheduleCommand("loginmgr") );
 			$req->success();
 		}

--- a/plugins/mediainfo/action.php
+++ b/plugins/mediainfo/action.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once( dirname(__FILE__).'/../_task/task.php' );
+require_once( dirname(__FILE__)."/../../php/ExternalPath.php");
 eval( getPluginConf( 'mediainfo' ) );
 
 class mediainfoSettings
@@ -57,7 +58,8 @@ if(isset($_REQUEST['hash']) &&
 						file_put_contents( $randName, $st->data["mediainfotemplate"] );
 						$flags = "--Inform=file://".escapeshellarg($randName);
 					}
-					$commands[] = getExternal("mediainfo")." ".$flags." ".escapeshellarg($filename);
+					$mediainfo = ExternalPath:load()->getExternalPathEx("mediainfo");
+					$commands[] = $mediainfo." ".$flags." ".escapeshellarg($filename);
 					$ret = $task->start($commands, rTask::FLG_WAIT);
 				}
 			}

--- a/plugins/ratio/ratio.php
+++ b/plugins/ratio/ratio.php
@@ -103,9 +103,10 @@ class rRatio
 	public function setHandlers()
 	{
 		global $checkTimesInterval;
+		$php = ExternalPath::load()->getPHP();
 		$req =  new rXMLRPCRequest( $this->hasTimes() ? 
 			rTorrentSettings::get()->getAbsScheduleCommand("ratio",$checkTimesInterval*60,
-				getCmd('execute').'={sh,-c,'.escapeshellarg(getPHP()).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(getUser()).' &}' ) :
+				getCmd('execute').'={sh,-c,'.escapeshellarg($php).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(getUser()).' &}' ) :
 			rTorrentSettings::get()->getRemoveScheduleCommand("ratio") );
 		return($req->success());
 	}

--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -871,9 +871,10 @@ class rRSSManager
 	}
 	public function setHandlers()
 	{
-	        $startAt = 0;
+	    $php = ExternalPath::load()->getPHP();
+		$startAt = 0;
 		$req = new rXMLRPCRequest( rTorrentSettings::get()->getScheduleCommand("rss",$this->data->interval,
-			getCmd('execute').'={sh,-c,'.escapeshellarg(getPHP()).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(getUser()).' & exit 0}', $startAt) );
+			getCmd('execute').'={sh,-c,'.escapeshellarg($php).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(getUser()).' & exit 0}', $startAt) );
 		if($req->success())
 		{
 			$this->setStartTime($startAt);

--- a/plugins/rutracker_check/action.php
+++ b/plugins/rutracker_check/action.php
@@ -16,10 +16,11 @@ if(isset($HTTP_RAW_POST_DATA))
 	}
 	if(count($ret))
 	{
+		$php = ExternalPath::load()->getPHP();
 		$fname = getTempDirectory().'rutorrent-prm-'.getUser().time();
 		file_put_contents( $fname, serialize( $ret ) );
-		shell_exec( getPHP()." -f ".escapeshellarg(dirname( __FILE__)."/batch_check.php")." ".escapeshellarg($fname)." ".escapeshellarg(getUser())." > /dev/null 2>&1 &" );
-//		shell_exec( getPHP()." -f ".escapeshellarg(dirname( __FILE__)."/batch_check.php")." ".escapeshellarg($fname)." ".getUser()." > /tmp/1 2>/tmp/2 &" );
+		shell_exec( $php." -f ".escapeshellarg(dirname( __FILE__)."/batch_check.php")." ".escapeshellarg($fname)." ".escapeshellarg(getUser())." > /dev/null 2>&1 &" );
+//		shell_exec( $php." -f ".escapeshellarg(dirname( __FILE__)."/batch_check.php")." ".escapeshellarg($fname)." ".getUser()." > /tmp/1 2>/tmp/2 &" );
 	}
 }
 

--- a/plugins/rutracker_check/init.php
+++ b/plugins/rutracker_check/init.php
@@ -13,7 +13,7 @@ else
 	if($updateInterval)
 	{
 		$req = new rXMLRPCRequest( $theSettings->getAbsScheduleCommand('rutracker_check',$updateInterval*60,
-			getCmd('execute').'={sh,-c,'.escapeshellarg(getPHP()).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(getUser()).' &}' ));
+			getCmd('execute').'={sh,-c,'.escapeshellarg($ep->getPHP()).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(getUser()).' &}' ));
 		if($req->success())
 			$theSettings->registerPlugin($plugin["name"],$pInfo["perms"]);
 		else

--- a/plugins/scheduler/init.php
+++ b/plugins/scheduler/init.php
@@ -6,7 +6,7 @@ $schd = rScheduler::load();
 $schd->apply();
 
 $req = new rXMLRPCRequest( $theSettings->getAbsScheduleCommand('scheduler',$updateInterval*60,
-	getCmd('execute').'={sh,-c,'.escapeshellarg(getPHP()).' '.escapeshellarg($rootPath.'/plugins/scheduler/update.php').' '.escapeshellarg(getUser()).' & exit 0}' ) );
+	getCmd('execute').'={sh,-c,'.escapeshellarg($ep->getPHP()).' '.escapeshellarg($rootPath.'/plugins/scheduler/update.php').' '.escapeshellarg(getUser()).' & exit 0}' ) );
 if($req->run() && !$req->fault)
 {
 	$theSettings->registerPlugin($plugin["name"],$pInfo["perms"]);

--- a/plugins/screenshots/action.php
+++ b/plugins/screenshots/action.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once( dirname(__FILE__).'/../_task/task.php' );
+require_once( dirname(__FILE__)."/../../php/ExternalPath.php");
 require_once( 'ffmpeg.php' );
 eval( getPluginConf( 'screenshots' ) );
 
@@ -8,6 +9,7 @@ $ret = array();
 if(isset($_REQUEST['cmd']))
 {
 	$st = ffmpegSettings::load();
+	$external = ExternalPath::load();
 	switch($_REQUEST['cmd'])
 	{
 		case "ffmpeg":
@@ -36,7 +38,7 @@ if(isset($_REQUEST['cmd']))
 						for($i=0; $i<$st->data['exfrmcount']; $i++)
 						{
 							$name = '"${dir}"/frame'.$i.($st->data['exformat'] ? '.png' : '.jpg');
-							$commands[] = getExternal("ffmpeg").
+							$commands[] = $external->getExternalPathEx("ffmpeg").
 								' -ss '.$offs.
 								" -i ".escapeshellarg($filename).
 								' -y -vframes 1 -an '.
@@ -69,7 +71,7 @@ if(isset($_REQUEST['cmd']))
 			if(@chdir( $dir ))
 			{
 				$randName = getTempFilename('screenshots-detail');
-				exec(escapeshellarg(getExternal('tar'))." -cf ".$randName." *.".($st->data['exformat'] ? 'png' : 'jpg'),$results,$return);
+				exec(escapeshellarg($external->getExternalPathEx('tar'))." -cf ".$randName." *.".($st->data['exformat'] ? 'png' : 'jpg'),$results,$return);
 				if(is_file($randName))
 				{
 					sendFile( $randName, "application/x-tar",  $_REQUEST['file'].'.tar', false );

--- a/plugins/spectrogram/action.php
+++ b/plugins/spectrogram/action.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once( dirname(__FILE__).'/../_task/task.php' );
+require_once( dirname(__FILE__)."/../../php/ExternalPath.php");
 eval( getPluginConf( 'spectrogram' ) );
 
 $ret = array();
@@ -31,7 +32,8 @@ if(isset($_REQUEST['cmd']))
 						$mediafile = basename($filename);
 						$commands = array();
 						$name = '"${dir}"/frame.png';
-						$commands[] = getExternal("sox").
+						$sox = ExternalPath:load()->getExternalPathEx("sox");
+						$commands[] = $sox.
 								" ".escapeshellarg($filename)." ".
 								implode( " ", array_map( "escapeshellarg", explode(" ",$arguments) ) ).
 								' -t '.escapeshellarg($mediafile).' -o '.

--- a/plugins/trafic/init.php
+++ b/plugins/trafic/init.php
@@ -5,7 +5,7 @@ require_once( '../plugins/trafic/ratios.php' );
 $st = getSettingsPath();
 makeDirectory( array( $st.'/trafic', $st.'/trafic/trackers', $st.'/trafic/torrents') );
 $req = new rXMLRPCRequest( $theSettings->getScheduleCommand("trafic",$updateInterval,
-	getCmd('execute').'={sh,-c,'.escapeshellarg(getPHP()).' '.escapeshellarg($rootPath.'/plugins/trafic/update.php').' '.escapeshellarg(getUser()).' & exit 0}' ) );
+	getCmd('execute').'={sh,-c,'.escapeshellarg($ep->getPHP()).' '.escapeshellarg($rootPath.'/plugins/trafic/update.php').' '.escapeshellarg(getUser()).' & exit 0}' ) );
 if($req->run() && !$req->fault)
        	$theSettings->registerPlugin($plugin["name"],$pInfo["perms"]);
 else

--- a/plugins/unpack/init.php
+++ b/plugins/unpack/init.php
@@ -6,15 +6,18 @@ require_once( 'unpack.php' );
 if($do_diagnostic)
 {
 	if(USE_UNZIP)
-		findRemoteEXE('unzip',"thePlugins.get('unpack').showError('theUILang.unzipNotFound');",$remoteRequests);
+		$remoteRequests->findRemoteEXE('unzip',"thePlugins.get('unpack').showError('theUILang.unzipNotFound');");
 	if(USE_UNRAR)
-		findRemoteEXE('unrar',"thePlugins.get('unpack').showError('theUILang.unrarNotFound');",$remoteRequests);
+		$remoteRequests->findRemoteEXE('unrar',"thePlugins.get('unpack').showError('theUILang.unrarNotFound');");
 }
 if(USE_UNZIP || USE_UNRAR)
 {
 	$up = rUnpack::load();
 	if($up->setHandlers())
 	{
+		$ep->fetchExternalPath('unzip');
+		$ep->fetchExternalPath('unrar');
+		
 		$jResult .= ("plugin.useUnzip = ".(USE_UNZIP ? "true;" : "false;"));
 		$jResult .= ("plugin.useUnrar = ".(USE_UNRAR ? "true;" : "false;"));
 		$jResult .= $up->get();

--- a/plugins/unpack/unpack.php
+++ b/plugins/unpack/unpack.php
@@ -2,6 +2,7 @@
 require_once( dirname(__FILE__)."/../../php/xmlrpc.php" );
 require_once( dirname(__FILE__)."/../../php/cache.php");
 require_once( dirname(__FILE__)."/../../php/settings.php");
+require_once( dirname(__FILE__)."/../../php/ExternalPath.php");
 require_once( dirname(__FILE__).'/../_task/task.php' );
 eval( getPluginConf( 'unpack' ) );
 
@@ -171,9 +172,10 @@ class rUnpack
 			if(!$qt->check())
 				return;
 		}
-
-		$pathToUnrar = getExternal("unrar");
-		$pathToUnzip = getExternal("unzip");
+		
+		$external = ExternalPath::load();
+		$pathToUnrar = $external->getExternalPathEx("unrar");
+		$pathToUnzip = $external->getExternalPathEx("unzip");
 		$zipPresent = false;
 		$rarPresent = false;		
 		$outPath = $this->path;
@@ -305,6 +307,8 @@ class rUnpack
 		);
 		if(($outPath!='') && !rTorrentSettings::get()->correctDirectory($outPath))	
 			$outPath = '';
+		
+		$external = ExternalPath::load();
 
 		if(!empty($mode))
 	        {
@@ -327,7 +331,7 @@ class rUnpack
 					$outPath = dirname($filename);
 
 				$commands = array();
-				$arh = getExternal( ($mode == "zip") ? 'unzip' : 'unrar' );
+				$arh = $external->getExternalPathEx( ($mode == "zip") ? 'unzip' : 'unrar' );
 				$commands[] = escapeshellarg($rootPath.'/plugins/unpack/un'.$mode.'_file.sh')." ".
 					escapeshellarg($arh)." ".
 					escapeshellarg($filename)." ".
@@ -385,8 +389,8 @@ class rUnpack
 					$mode = ($rarPresent && $zipPresent) ? 'all' : ($rarPresent ? 'rar' : ($zipPresent ? 'zip' : null));
 					if($mode)
 					{
-						$pathToUnrar = getExternal("unrar");
-						$pathToUnzip = getExternal("unzip");
+						$pathToUnrar = $external->getExternalPathEx("unrar");
+						$pathToUnzip = $external->getExternalPathEx("unzip");
 						$arh = (($mode == "zip") ? $pathToUnzip : $pathToUnrar);
 						if(is_dir($basename))
 						{
@@ -430,13 +434,14 @@ class rUnpack
 		return($ret);
 	}
 
-	public function setHandlers()
+	public function setHandlers($php)
 	{
 		global $rootPath;
 		if($this->enabled)
 		{
+			$php = ExternalPath::load()->getPHP();
 			$cmd =  rTorrentSettings::get()->getOnFinishedCommand( array('unpack'.getUser(), 
-					getCmd('execute').'={'.getPHP().','.$rootPath.'/plugins/unpack/update.php,$'.getCmd('d.get_directory').'=,$'.getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').
+					getCmd('execute').'={'.$php.','.$rootPath.'/plugins/unpack/update.php,$'.getCmd('d.get_directory').'=,$'.getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').
 					'=,$'.getCmd('d.get_custom1').'=,$'.getCmd('d.get_name').'=,$'.getCmd('d.get_hash').'=,$'.getCmd('d.get_custom').'=x-dest,'.getUser().'}'));
 		}
 		else

--- a/plugins/xmpp/xmpp.php
+++ b/plugins/xmpp/xmpp.php
@@ -129,8 +129,9 @@ class rXmpp
 		$req = new rXMLRPCRequest();
 		if ( $this->message !== '' && isset($this->jabberServer) && isset($this->jabberLogin) && isset($this->jabberPasswd) && isset($this->jabberFor))
 		{
-		    $cmd = $theSettings->getOnFinishedCommand(array('xmpp'.getUser(), 
-			    getCmd('execute.nothrow.bg').'={'.getPHP().','.$pathToXmpp.'/notify.php,"$'.getCmd('d.name').'=","'.getUser().'"}'
+		    $php = ExternalPath::load()->getPHP();
+			$cmd = $theSettings->getOnFinishedCommand(array('xmpp'.getUser(), 
+			    getCmd('execute.nothrow.bg').'={'$php.','.$pathToXmpp.'/notify.php,"$'.getCmd('d.name').'=","'.getUser().'"}'
 			    ));
 		}
 		else


### PR DESCRIPTION
This pull request improves the internal method of looking up file paths on ruTorrent. 

**Some highlights include:**

1. A file path cache is created which stores the location of all the binaries in a .dat file. This cache is persistent in between page refreshes. It improves the overall page loading speed and reduces web server load (especially with multiple instances running).

2. An improved method of looking up the location of binaries on Linux is implemented. The `which` command is sent via php `shell_exec`. This has performance advantages. It also works in situations where the path lookup method will not work.

Most Linux distributions come with this package already installed. The ones that don't can easily add it. It might be worth adding a note about this package on the ruTorrent wiki.